### PR TITLE
[feature] Install packages for both Claude and Cursor

### DIFF
--- a/modelcontextprotocol/pyproject.toml
+++ b/modelcontextprotocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videodb-director-mcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "VideoDB MCP Server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/modelcontextprotocol/uv.lock
+++ b/modelcontextprotocol/uv.lock
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "videodb-director-mcp"
-version = "0.1.2"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/modelcontextprotocol/videodb_director_mcp/cli_commands.py
+++ b/modelcontextprotocol/videodb_director_mcp/cli_commands.py
@@ -82,8 +82,8 @@ def install_for_cursor() -> None:
     print("🚀 Enjoy supercharged video capabilities!\n")
 
 
-def install_for_both() -> None:
-    """Install videodb-director-mcp for both Claude and Cursor IDE."""
+def install_for_all() -> None:
+    """Install videodb-director-mcp for all clients. Currently they are: Claude and Cursor IDE."""
     api_key = get_api_key()
     save_mcp_config("claude", api_key)
     save_mcp_config("cursor", api_key)

--- a/modelcontextprotocol/videodb_director_mcp/cli_commands.py
+++ b/modelcontextprotocol/videodb_director_mcp/cli_commands.py
@@ -82,7 +82,7 @@ def install_for_cursor() -> None:
     api_key = get_api_key()
     save_mcp_config("cursor", api_key)
     print("\n🎉 Cursor IDE configuration complete!")
-    print("🔁 Please restart Cursor IDE to apply changes.")
+    print("✅ videodb-director is now available in Cursor.")
     print("🚀 Enjoy supercharged video capabilities!\n")
 
 
@@ -92,5 +92,5 @@ def install_for_all() -> None:
     save_mcp_config("claude", api_key)
     save_mcp_config("cursor", api_key)
     print("\n🎉 Configuration for Claude and Cursor completed successfully!")
-    print("🔁 Restart both apps to activate videodb-director-mcp.")
+    print("🔁 Please restart Claude Desktop to apply changes.")
     print("🚀 Enjoy supercharged video capabilities!\n")

--- a/modelcontextprotocol/videodb_director_mcp/cli_commands.py
+++ b/modelcontextprotocol/videodb_director_mcp/cli_commands.py
@@ -20,7 +20,9 @@ def load_config(config_path: Path) -> dict:
             with config_path.open("r", encoding="utf-8") as f:
                 return json.load(f)
         except json.JSONDecodeError:
-            return {}    
+            print(f"⚠️ Failed to parse JSON config at: {config_path} — falling back to empty config.")
+            return {}   
+    print(f"📁 No config file found at: {config_path} — creating a new one.") 
     return {}
 
 
@@ -59,8 +61,10 @@ def save_mcp_config(app: str, api_key: str) -> None:
     """Save MCP config for Claude or Cursor."""
     config_path = get_config_path(app)
     config_data = load_config(config_path)
-    config_data.setdefault("mcpServers", {})
-    config_data["mcpServers"]["videodb-director"] = create_mcp_entry(api_key, stdio=(app == "cursor"))
+    mcp_servers = config_data.get("mcpServers", {})
+    mcp_servers["videodb-director"] = create_mcp_entry(api_key, stdio=(app == "cursor"))
+    config_data["mcpServers"] = mcp_servers
+
     save_config(config_path, config_data)
 
 

--- a/modelcontextprotocol/videodb_director_mcp/cli_commands.py
+++ b/modelcontextprotocol/videodb_director_mcp/cli_commands.py
@@ -1,0 +1,92 @@
+import json
+import os
+import platform
+from pathlib import Path
+
+def get_api_key() -> str:
+    """Prompt the user for their VideoDB MCP API key."""
+    print("\n🔑 VideoDB API Key is required for advanced functionality.")
+    print("🌐 Get your API key at: https://console.videodb.io/dashboard")
+    print("Note: You can leave this empty, but the 'call_director' tool will not be available.\n")
+    
+    return input("Enter your VideoDB API Key (or press Enter to skip): ").strip()
+
+
+def load_config(config_path: Path) -> dict:
+    """Load configuration from a file, returning an empty dict if unreadable or missing."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    if config_path.exists():
+        try:
+            with config_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}    
+    return {}
+
+
+def save_config(config_path: Path, config_data: dict) -> None:
+    """Save configuration data to a file."""
+    with config_path.open("w", encoding="utf-8") as f:
+        json.dump(config_data, f, indent=4)
+
+
+def get_config_path(app: str) -> Path:
+    """Return the appropriate config path based on platform and app."""
+    if platform.system() == "Windows":
+        if app == "claude":
+            return Path(os.getenv("APPDATA")) / "Claude" / "claude_desktop_config.json"
+        return Path(os.getenv("USERPROFILE")) / ".cursor" / "mcp.json"
+    else:
+        if app == "claude":
+            return Path.home() / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        return Path.home() / ".cursor" / "mcp.json"
+
+
+def create_mcp_entry(api_key: str, stdio: bool = False) -> dict:
+    """Create the MCP server entry config."""
+    entry = {
+        "command": "videodb-director-mcp",
+        "args": []
+    }
+    if api_key:
+        entry["env"] = {"VIDEODB_API_KEY" : api_key}
+    if stdio:
+        entry["type"] = "stdio"
+    return entry
+
+
+def save_mcp_config(app: str, api_key: str) -> None:
+    """Save MCP config for Claude or Cursor."""
+    config_path = get_config_path(app)
+    config_data = load_config(config_path)
+    config_data.setdefault("mcpServers", {})
+    config_data["mcpServers"]["videodb-director"] = create_mcp_entry(api_key, stdio=(app == "cursor"))
+    save_config(config_path, config_data)
+
+
+def install_for_claude() -> None:
+    """Install videodb-director-mcp for Claude Desktop."""
+    api_key = get_api_key()
+    save_mcp_config("claude", api_key)
+    print("\n🎉 Claude Desktop configuration complete!")
+    print("🔁 Please restart Claude Desktop to apply changes.")
+    print("🚀 Enjoy supercharged video capabilities!\n")
+
+
+def install_for_cursor() -> None:
+    """Install videodb-director-mcp for Cursor IDE."""
+    api_key = get_api_key()
+    save_mcp_config("cursor", api_key)
+    print("\n🎉 Cursor IDE configuration complete!")
+    print("🔁 Please restart Cursor IDE to apply changes.")
+    print("🚀 Enjoy supercharged video capabilities!\n")
+
+
+def install_for_both() -> None:
+    """Install videodb-director-mcp for both Claude and Cursor IDE."""
+    api_key = get_api_key()
+    save_mcp_config("claude", api_key)
+    save_mcp_config("cursor", api_key)
+    print("\n🎉 Configuration for Claude and Cursor completed successfully!")
+    print("🔁 Restart both apps to activate videodb-director-mcp.")
+    print("🚀 Enjoy supercharged video capabilities!\n")

--- a/modelcontextprotocol/videodb_director_mcp/main.py
+++ b/modelcontextprotocol/videodb_director_mcp/main.py
@@ -11,7 +11,7 @@ from mcp.server.fastmcp import FastMCP
 from videodb_director_mcp.cli_commands import (
     install_for_claude,
     install_for_cursor,
-    install_for_both
+    install_for_all
 )
 from videodb_director_mcp.constants import CODE_ASSISTANT_TXT_URL, DOCS_ASSISTANT_TXT_URL, DIRECTOR_CALL_DESCRIPTION, DIRECTOR_API
 
@@ -148,7 +148,7 @@ def parse_arguments():
     )
     parser.add_argument(
         "--install",
-        choices=["claude", "cursor", "both"],
+        choices=["claude", "cursor", "all"],
         help="🔧 Configure the MCP server in 'claude' and/or 'cursor'."
     )
     return parser.parse_args()
@@ -165,8 +165,8 @@ def main():
         install_for_cursor()
         return
     
-    if args.install == "both":
-        install_for_both()
+    if args.install == "all":
+        install_for_all()
         return
     
     if args.api_key:

--- a/modelcontextprotocol/videodb_director_mcp/main.py
+++ b/modelcontextprotocol/videodb_director_mcp/main.py
@@ -7,8 +7,14 @@ import argparse
 import socketio
 import webbrowser
 from typing import Any
-from videodb_director_mcp.constants import CODE_ASSISTANT_TXT_URL, DOCS_ASSISTANT_TXT_URL, DIRECTOR_CALL_DESCRIPTION, DIRECTOR_API
 from mcp.server.fastmcp import FastMCP
+from videodb_director_mcp.cli_commands import (
+    install_for_claude,
+    install_for_cursor,
+    install_for_both
+)
+from videodb_director_mcp.constants import CODE_ASSISTANT_TXT_URL, DOCS_ASSISTANT_TXT_URL, DIRECTOR_CALL_DESCRIPTION, DIRECTOR_API
+
 
 mcp = FastMCP("videodb-director")
 
@@ -138,7 +144,12 @@ def parse_arguments():
     parser.add_argument(
         "--api-key",
         type=str,
-        help="The VideoDB API key required to connect to the VideoDB service.",
+        help="🔑 The VideoDB API key required to connect to the VideoDB service.",
+    )
+    parser.add_argument(
+        "--install",
+        choices=["claude", "cursor", "both"],
+        help="🔧 Configure the MCP server in 'claude' and/or 'cursor'."
     )
     return parser.parse_args()
 
@@ -146,6 +157,18 @@ def parse_arguments():
 def main():
     args = parse_arguments()
 
+    if args.install == "claude":
+        install_for_claude()
+        return
+    
+    if args.install == "cursor":
+        install_for_cursor()
+        return
+    
+    if args.install == "both":
+        install_for_both()
+        return
+    
     if args.api_key:
         os.environ["VIDEODB_API_KEY"] = args.api_key
 


### PR DESCRIPTION
This PR adds the MCP server automatically when the user runs the following command:

### Step 1: Install the package 

Windows:
```
python -m pip install videodb-director-mcp
```

MacOS: 
```
python3 -m pip install videodb-director-mcp
```

### Step 2: Run the command to configure the MCP Servers

For Claude:
```
videodb-director-mcp --install=claude
```

For Cursor:
```
videodb-director-mcp --install=cursor
```

For both:
```
videodb-director-mcp --install=both
```

