### PR TITLE
feat: update the tool command to `uvx`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ We need to install uv first.
 
 For macOS/Linux:
 ```
-brew install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 For Windows:
 
@@ -84,7 +84,7 @@ For Windows:
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-You can visit the installation steps for `uv` [here](https://docs.astral.sh/uv/getting-started/installation)
+You can also visit the installation steps of `uv` for more details [here](https://docs.astral.sh/uv/getting-started/installation)
 
 ## Run the MCP Server
 You can run the MCP server using `uvx` using the following command

--- a/README.md
+++ b/README.md
@@ -69,19 +69,11 @@ A streamlined file following the [Answer.AI llms.txt proposal](https://github.co
 
 ### 3. MCP (Model Context Protocol)
 
-The VideoDB MCP Server connects with the Director backend framework, providing a single tool for many workflows. For development, it can be installed and used in multiple ways, including globally via pip or with pipx for isolated environments. For more details on MCPs, please visit [here](https://docs.videodb.io/add-videodb-mcp-server-in-clients-108)
+The VideoDB MCP Server connects with the Director backend framework, providing a single tool for many workflows. For development, it can be installed and used via uvx for isolated environments. For more details on MCPs, please visit [here](https://docs.videodb.io/add-videodb-mcp-server-in-clients-108)
 
 **Using uvx**
 
-```uvx run videodb-director-mcp --api-key=VIDEODB_API_KEY```
-
-**Using pip:**
-
-`pip install videodb-director-mcp`
-
-The MCP server can now be started with the following command:
-
-```videodb-director-mcp --api-key=VIDEODB_API_KEY```
+```uvx videodb-director-mcp --api-key=VIDEODB_API_KEY```
 
 <br/>
        

--- a/README.md
+++ b/README.md
@@ -71,9 +71,27 @@ A streamlined file following the [Answer.AI llms.txt proposal](https://github.co
 
 The VideoDB MCP Server connects with the Director backend framework, providing a single tool for many workflows. For development, it can be installed and used via uvx for isolated environments. For more details on MCPs, please visit [here](https://docs.videodb.io/add-videodb-mcp-server-in-clients-108)
 
-**Using uvx**
+## Install `uv`
+We need to install uv first.
 
-```uvx videodb-director-mcp --api-key=VIDEODB_API_KEY```
+For macOS/Linux:
+```
+brew install uv
+```
+For Windows:
+
+```
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+You can visit the installation steps for `uv` [here](https://docs.astral.sh/uv/getting-started/installation)
+
+## Run the MCP Server
+You can run the MCP server using `uvx` using the following command
+
+```
+uvx videodb-director-mcp --api-key=VIDEODB_API_KEY
+```
 
 <br/>
        

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -5,7 +5,7 @@ We need to install uv first.
 
 For macOS/Linux:
 ```
-brew install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 For Windows:
 
@@ -13,7 +13,7 @@ For Windows:
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-You can visit the installation steps for `uv` [here](https://docs.astral.sh/uv/getting-started/installation)
+You can also visit the installation steps of `uv` for more details [here](https://docs.astral.sh/uv/getting-started/installation)
 
 ## Run the MCP Server
 You can run the MCP server using `uvx` using the following command

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -1,34 +1,21 @@
 To add the MCP server in any config driven MCP Client, following is how the commands and arguments will look like
 
-## 1. Install the package
-
-```
-pip install videodb-director-mcp
-```
-
-## 2. Use the MCP Server!
-
-Normally as a CLI Command
-
-```
-videodb-director-mcp --api-key=VIDEODB_API_KEY
-```
-
-Using `pipx`
-
-```
-pipx run videodb-director-mcp --api-key=VIDEODB_API_KEY
-```
-
-Using `uvx`
+## Run the MCP Server
+You can run the MCP server using `uvx` using the following command
 
 ```
 uvx videodb-director-mcp --api-key=VIDEODB_API_KEY
 ```
 
-## 3. Add the VideoDB Director MCP Server in your favorite Client
+## Add the VideoDB Director MCP Server in your favorite Client
 
 ### Claude Desktop
+
+To configure VideoDB Director MCP server in Claude, you can run the following command
+
+```uvx videodb-director-mcp --install=claude```
+
+You can manually configure the MCP Server by following these steps:
 
 1. Open the `claude_desktop_config.json` file
 
@@ -50,14 +37,20 @@ uvx videodb-director-mcp --api-key=VIDEODB_API_KEY
    {
      "mcpServers": {
        "videodb-director": {
-         "command": "videodb-director-mcp",
-         "args": ["--api-key=<VIDEODB-API-KEY>"]
+         "command": "uvx",
+         "args": ["videodb-director-mcp", "--api-key=<VIDEODB-API-KEY>"]
        }
      }
    }
    ```
 
 ### Cursor
+
+To configure VideoDB Director MCP server in Cursor, you can run the following command
+
+```uvx videodb-director-mcp --install=cursor```
+
+You can manually configure the MCP Server by following these steps:
 
 1. Inside Cursor, go to **Settings > Cursor Settings**
 2. Click on **MCP**
@@ -68,9 +61,14 @@ uvx videodb-director-mcp --api-key=VIDEODB_API_KEY
    {
      "mcpServers": {
        "videodb-director": {
-         "command": "videodb-director-mcp",
-         "args": ["--api-key=<VIDEODB-API-KEY>"]
+         "command": "uvx",
+         "args": ["videodb-director-mcp", "--api-key=<VIDEODB-API-KEY>"]
        }
      }
    }
    ```
+
+### Install in Claude and Cursor at the same time.
+You can configure VideoDB Director MCP server in Claude and Cursor together, by running the following command
+
+```uvx videodb-director-mcp --install=all```

--- a/modelcontextprotocol/README.md
+++ b/modelcontextprotocol/README.md
@@ -1,5 +1,20 @@
 To add the MCP server in any config driven MCP Client, following is how the commands and arguments will look like
 
+## Install `uv`
+We need to install uv first.
+
+For macOS/Linux:
+```
+brew install uv
+```
+For Windows:
+
+```
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+You can visit the installation steps for `uv` [here](https://docs.astral.sh/uv/getting-started/installation)
+
 ## Run the MCP Server
 You can run the MCP server using `uvx` using the following command
 

--- a/modelcontextprotocol/videodb_director_mcp/cli_commands.py
+++ b/modelcontextprotocol/videodb_director_mcp/cli_commands.py
@@ -47,8 +47,8 @@ def get_config_path(app: str) -> Path:
 def create_mcp_entry(api_key: str, stdio: bool = False) -> dict:
     """Create the MCP server entry config."""
     entry = {
-        "command": "videodb-director-mcp",
-        "args": []
+        "command": "uvx",
+        "args": ["videodb-director-mcp"]
     }
     if api_key:
         entry["env"] = {"VIDEODB_API_KEY" : api_key}


### PR DESCRIPTION
- updated the tool installation method from CLI command `videodb-director-mcp` to `uvx`
- MCP server configured using `--install` will now be configured using `uvx` instead of the locally downloaded CLI command `videodb-director-mcp`