### PR TITLE
fix: added '/' path in namespaces explicitly

### DIFF
--- a/modelcontextprotocol/pyproject.toml
+++ b/modelcontextprotocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videodb-director-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "VideoDB MCP Server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/modelcontextprotocol/uv.lock
+++ b/modelcontextprotocol/uv.lock
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "videodb-director-mcp"
-version = "0.1.3"
+version = "0.1.6"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/modelcontextprotocol/videodb_director_mcp/constants.py
+++ b/modelcontextprotocol/videodb_director_mcp/constants.py
@@ -2,7 +2,7 @@ CODE_ASSISTANT_TXT_URL = "https://videodb.io/llms-full.txt"
 
 DOCS_ASSISTANT_TXT_URL = "https://video-db.github.io/agent-toolkit/context/docs/docs_context.md"
 
-DIRECTOR_API = "https://api2.director.videodb.io/chat"
+DIRECTOR_API = "https://api2.director.videodb.io"
 
 DIRECTOR_CALL_DESCRIPTION = """
 The Director tool orchestrates specialized agents within the VideoDB server, efficiently handling multimedia and video-related queries. Clients should send queries that Director can interpret clearly, specifying tasks in natural language. Director will then delegate these queries to appropriate agents for optimized results, utilizing defaults and contextual information if explicit parameters are not provided.

--- a/modelcontextprotocol/videodb_director_mcp/main.py
+++ b/modelcontextprotocol/videodb_director_mcp/main.py
@@ -135,7 +135,7 @@ async def call_director(
     try:
         sio.connect(
             url,
-            namespaces=["/chat"],
+            namespaces=["/", "/chat"],
             headers=headers,
             wait=True,
             wait_timeout=10,


### PR DESCRIPTION
This PR Fixes the."One or more namespaces failed to connect" errors.
- added the '/' path in the namespaces 
- gave the server url without '/chat' path for connection